### PR TITLE
Fix handling of empty string in {params[n]} expression formatting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,8 @@ function createMessageReporter(options){
             index:index,
             context: context
           }) : '';
-      if (!output || output.length === 0){
+      var isEmptyStringParam = part === 'params' && output === '';
+      if ((!output || output.length === 0) && !isEmptyStringParam){
         // handle removal
         var indexOfPlaceHolder = current.indexOf(partPlaceholder);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -21,6 +21,18 @@ describe('z-schema-errors', function(){
       message.should.equal("An error occurred 'Invalid property \"invalid_value\"' on property elements (The elements).");
     });
 
+    it('should return default message for ENUM_MISMATCH code (empty string)', function(){
+      var error = {
+        code: 'ENUM_MISMATCH',
+        params: [ '' ],
+        path: '#/elements',
+        description: 'The elements'
+      };
+
+      var message = reporter.extractMessage({ report: { errors: [error] } });
+      message.should.equal("An error occurred 'Invalid property \"\"' on property elements (The elements).");
+    });
+
     it('should return default message for any other code', function(){
       var error = {
         code: 'INVALID_FORMAT',


### PR DESCRIPTION
When a property value is an empty string and the validation fails (ex. ENUM_MISMATCH), replace the `{params[0]}` expression with the empty string instead of leaving the expression in place.

Before this PR, the output message is something like `An error occurred 'Invalid property "{params[0]}"' on property elements (The elements).`. After the PR, the output message is: `An error occurred 'Invalid property ""' on property elements (The elements).`.